### PR TITLE
Add minimum width to support inline-blocks

### DIFF
--- a/lib/ractive-widgets-vscroll.js
+++ b/lib/ractive-widgets-vscroll.js
@@ -45,6 +45,7 @@ Ractive.components.vScroll = Ractive.extend({
 							
 							if(that.get('visible').indexOf(ind * 1) == -1){
 								el.style.minHeight = "1px";
+								el.style.minWidth = "1px";
 								that.push('visible', ind * 1).then(function(){
 									
 								});
@@ -54,7 +55,9 @@ Ractive.components.vScroll = Ractive.extend({
 							var idx = that.get('visible').indexOf(ind * 1);
 							if(idx != -1) {
 								var ofh = el.offsetHeight - 1;
+								var ofw = el.offsetWidth - 1;
 								el.style.minHeight = ofh + "px";
+								el.style.minWidth = ofw + "px";
 								that.splice('visible', idx, 1).then(function() {
 										
 									console.log(that.get('visible'), 'xxxxxxxxxxxx');


### PR DESCRIPTION
If your v-block's display: is set to inline-block, it doesn't scroll properly once it has removed the data because the inline-block needs a width > 0.